### PR TITLE
Add Python 3 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Usage
         option domain-name-servers 10.24.199.136,10.24.199.137;
     }
     """
-    print pydhcpdparser.parser.parse(conf)
+    print(pydhcpdparser.parser.parse(conf))
 
 
 OR
@@ -68,7 +68,7 @@ OR
     from pydhcpdparser import parser
 
     conf = "zone 17.127.10.in-addr.arpa. { key DHCPUPDATE; }"
-    print parser.parse(conf)
+    print(parser.parse(conf))
 
 
 OR
@@ -77,9 +77,9 @@ OR
 
     from pydhcpdparser import *
 
-    with open("/etc/dhcp/dhcpd.conf) as f:
+    with open("/etc/dhcp/dhcpd.conf") as f:
         conf = f.read()
-        print parser.parse(conf)
+    print(parser.parse(conf))
 
 
 Installing **pydhcpdparser**

--- a/pydhcpdparser/__init__.py
+++ b/pydhcpdparser/__init__.py
@@ -1,2 +1,2 @@
-from dhcp_conf_parser import parser
+from .dhcp_conf_parser import parser
 __all__ = ['parser']

--- a/pydhcpdparser/dhcp_conf_parser.py
+++ b/pydhcpdparser/dhcp_conf_parser.py
@@ -1,6 +1,7 @@
 """
 DHCPD Configuration parser
 """
+from __future__ import print_function
 
 import ply.lex
 import ply.yacc
@@ -673,7 +674,7 @@ def t_newline(t):
 
 
 def t_error(t):
-    print t
+    print(t)
     raise Exception("Lexical error at %r line %d" % (t.value, t.lineno))
 
 
@@ -1166,9 +1167,9 @@ def p_str_value_error(p):
     if p[1].type in tokens:
         parser.errok()
         p[0] = p[1].value + p[2]
-        print "Error probably handled"
+        print("Error probably handled")
     else:
-        print "Exception at handling Syntax error in input "
+        print("Exception at handling Syntax error in input ")
         p_error(p[1])
         raise SyntaxError
 

--- a/pydhcpdparser/test_dhcp_conf_parser.py
+++ b/pydhcpdparser/test_dhcp_conf_parser.py
@@ -1,10 +1,11 @@
 from unittest import TestCase
+import ast
 import ddt
 from . import dhcp_conf_parser
-from test_files.dhcpd_subnets_conf_data import *
-from test_files.dhcpd_conf_data import *
-from test_files.dhcpd_global_stmt_data import *
-from test_files.dhcpd_host_stmt_data import *
+from .test_files.dhcpd_subnets_conf_data import *
+from .test_files.dhcpd_conf_data import *
+from .test_files.dhcpd_global_stmt_data import *
+from .test_files.dhcpd_host_stmt_data import *
 
 
 @ddt.ddt
@@ -13,7 +14,12 @@ class TestDHCPConfParser(TestCase):
     @ddt.file_data("test_files/dhcpd_zone_conf.json")
     def test_zone_stmt(self, conf, exp):
         value = dhcp_conf_parser.parser.parse(conf)
-        self.assertEqual(exp, str(value))
+
+        # We convert the expected value to literal (list/dict etc)
+        # so we won't have any problem if the keys order differs
+        exp = ast.literal_eval(exp)
+
+        self.assertEqual(exp, value)
 
     @ddt.data((multi_subnets, exp_multi_subnet),
               (subnet_pool_empty_block, exp_subnet_pool_empty_block),

--- a/pydhcpdparser/test_files/dhcpd_zone_conf.json
+++ b/pydhcpdparser/test_files/dhcpd_zone_conf.json
@@ -1,22 +1,22 @@
 {
     "zone_test": {
         "conf": "zone 17.127.10.in-addr.arpa. { primary 127.0.0.1; key DHCP_UPDATE; }",
-        "exp": "[{u'zone': {'name': u'17.127.10.in-addr.arpa. ', u'key': u'DHCP_UPDATE', u'primary': u'127.0.0.1'}}]"
+        "exp": "[{'zone': {'name': '17.127.10.in-addr.arpa. ', 'key': 'DHCP_UPDATE', 'primary': '127.0.0.1'}}]"
     },
     "zone_empty_block": {
         "conf": "zone 17.127.10.in-addr.arpa. { }",
-        "exp": "[{u'zone': {'name': u'17.127.10.in-addr.arpa. '}}]"
+        "exp": "[{'zone': {'name': '17.127.10.in-addr.arpa. '}}]"
     },
     "zone_primary_only": {
         "conf": "zone 17.127.10.in-addr.arpa. { primary 127.0.0.1; }",
-        "exp": "[{u'zone': {'name': u'17.127.10.in-addr.arpa. ', u'primary': u'127.0.0.1'}}]"
+        "exp": "[{'zone': {'name': '17.127.10.in-addr.arpa. ', 'primary': '127.0.0.1'}}]"
     },
     "zone_key_only": {
         "conf": "zone 17.127.10.in-addr.arpa. { key DHCPUPDATE; }",
-        "exp": "[{u'zone': {'name': u'17.127.10.in-addr.arpa. ', u'key': u'DHCPUPDATE'}}]"
+        "exp": "[{'zone': {'name': '17.127.10.in-addr.arpa. ', 'key': 'DHCPUPDATE'}}]"
     },
     "zone_quoted_key": {
         "conf": "zone 17.127.10.in-addr.arpa. { key \"DHCPUPDATE\"; }",
-        "exp": "[{u'zone': {'name': u'17.127.10.in-addr.arpa. ', u'key': u'\"DHCPUPDATE\"'}}]"
+        "exp": "[{'zone': {'name': '17.127.10.in-addr.arpa. ', 'key': '\"DHCPUPDATE\"'}}]"
     }
 }


### PR DESCRIPTION
This PR adds Python 3 support.

PS: I have tested this only on python 3 (with `python3  -m uninttest`).

PS2: Also, could you add a LICENSE to the project? It would be nice if that would be e.g. MIT/BSD/Apache2.
