### PR TITLE
Update PyPI classifiers to reflect accurate license data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ classifier =
     Intended Audience :: Developers
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators
-    License :: OSI Approved :: GNU Affero General Public License v3
+    License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 2


### PR DESCRIPTION
The license at:
https://github.com/jay-g-mehta/pydhcpdparser/blob/master/LICENSE#L2C16-L2C16 is
GNU General Public License v3 (GPLv3) 

According to the [PyPI classifiers list](https://pypi.org/classifiers/) the appropriate tag is `License :: OSI Approved :: GNU General Public License v3 (GPLv3)`

The reason that it is very important for this information to be accurate is that in an enterprise environment, security tools like [Sonatype Nexus IQ](https://help.sonatype.com/iqserver) are used to manage open source software risk. Nexus IQ specifically can be configured to [classify packages according to their license](https://help.sonatype.com/iqserver/managing/policy-management/license-threat-groups). This prevents developers from inadvertently using licenses like [GNU General Public License v2.0](https://www.tldrlegal.com/license/gnu-general-public-license-v2) without realizing that they may be legally obligated to make their entire project open source.

![image](https://github.com/jay-g-mehta/pydhcpdparser/assets/7910938/2288bc85-43b3-4b24-afe8-bbd609b230f5)


Adding this license information may increase the availability of pydhcpdparser within enterprise environments that are willing to use GPLv3 but restrict AGPLV3 licenses.

Please remember to redeploy to PyPI to ensure the new classifiers are pushed!